### PR TITLE
Change base framework from Foundation to UIKit

### DIFF
--- a/example/Blog.swift
+++ b/example/Blog.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 struct Blog {
   let id: Int

--- a/example/JsonGen.swift
+++ b/example/JsonGen.swift
@@ -4,7 +4,7 @@
 //  Json encoders and decoders for some base Swift and Foundation types.
 //
 
-import Foundation
+import UIKit
 
 typealias AnyJson = AnyObject
 typealias JsonObject = [String: AnyJson]
@@ -128,6 +128,48 @@ extension NSDate
 
   func encodeJson() -> String {
     return JsonGenDateFormatter.withTimeZone.stringFromDate(self)
+  }
+}
+
+extension UIColor {
+  class func decodeJson(json: AnyObject) -> UIColor? {
+    if let str = json as? String {
+      let hexString = str.stringByTrimmingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+      let scanner = NSScanner(string: str)
+
+      if (hexString.hasPrefix("#")) {
+        scanner.scanLocation = 1
+      }
+
+      var color:UInt32 = 0
+      scanner.scanHexInt(&color)
+
+      let mask = 0x000000FF
+      let r = Int(color >> 16) & mask
+      let g = Int(color >> 8) & mask
+      let b = Int(color) & mask
+
+      let red   = CGFloat(r) / 255.0
+      let green = CGFloat(g) / 255.0
+      let blue  = CGFloat(b) / 255.0
+
+      return UIColor(red:red, green:green, blue:blue, alpha:1)
+    }
+
+    return nil
+  }
+
+  func encodeJson() -> NSObject {
+    var r:CGFloat = 0
+    var g:CGFloat = 0
+    var b:CGFloat = 0
+    var a:CGFloat = 0
+
+    getRed(&r, green: &g, blue: &b, alpha: &a)
+
+    let rgb:Int = (Int)(r*255)<<16 | (Int)(g*255)<<8 | (Int)(b*255)<<0
+
+    return NSString(format:"#%06x", rgb) ?? NSNull()
   }
 }
 

--- a/lib/JsonGen.js
+++ b/lib/JsonGen.js
@@ -52,7 +52,7 @@ function generate() {
             return isSwift && !isJsonGen && !isExtensions;
         });
         var filenamesString = files.map(function (f) { return '"' + f.fullname + '"'; }).join(' ');
-        var cmd = 'xcrun swiftc -sdk "$(xcrun --show-sdk-path --sdk macosx)" -dump-ast ' + filenamesString;
+        var cmd = 'xcrun swiftc -sdk "$(xcrun --show-sdk-path --sdk iphoneos)" -target armv7-apple-ios9.0 -dump-ast ' + filenamesString;
         var opts = {
             maxBuffer: 200 * 1024 * 1024
         };

--- a/lib/JsonGen.ts
+++ b/lib/JsonGen.ts
@@ -75,7 +75,7 @@ function generate() {
 
     var filenamesString = files.map(f => '"' + f.fullname + '"').join(' ');
 
-    var cmd = 'xcrun swiftc -sdk "$(xcrun --show-sdk-path --sdk macosx)" -dump-ast ' + filenamesString
+    var cmd = 'xcrun swiftc -sdk "$(xcrun --show-sdk-path --sdk iphoneos)" -target armv7-apple-ios9.0 -dump-ast ' + filenamesString
     var opts = {
       maxBuffer: 200*1024*1024
     }

--- a/lib/SwiftPrinter.js
+++ b/lib/SwiftPrinter.js
@@ -21,7 +21,7 @@ function makeFile(file, globalAttrs, filename) {
     lines.push('//  See for details: https://github.com/tomlokhorst/swift-json-gen');
     lines.push('//');
     lines.push('');
-    lines.push('import Foundation');
+    lines.push('import UIKit');
     lines.push('');
     enums.forEach(function (s) {
         var createDecoder = !decoderExists(s.baseName);

--- a/lib/SwiftPrinter.ts
+++ b/lib/SwiftPrinter.ts
@@ -29,7 +29,7 @@ function makeFile(file: any[], globalAttrs: GlobalAttrs, filename: string): stri
   lines.push('//  See for details: https://github.com/tomlokhorst/swift-json-gen')
   lines.push('//');
   lines.push('');
-  lines.push('import Foundation');
+  lines.push('import UIKit');
   lines.push('');
 
   enums.forEach(function (s) {


### PR DESCRIPTION
I expect this to be rejected, but wanted to point out what I did to make swift-json-gen more robust for UIKit. I think ultimately I would just go down the JSON vs Domain model path in the future instead.

I added support for UIColor (expecting a hex string), as it was my immediate need.
