### PR TITLE
Prevent nil when using the 12 hour clock

### DIFF
--- a/example/JsonGen.swift
+++ b/example/JsonGen.swift
@@ -163,6 +163,7 @@ extension NSDate
     static let withTimeZone : NSDateFormatter = {
       let formatter = NSDateFormatter()
       formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+      formatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
 
       return formatter
     }()


### PR DESCRIPTION
When you switch the device to the 12 hour clock (general > date & time > 24 hour slide), this method will return nil when the HH is greater than 12.
This is fixed when you set the locale. Since the format is specific, we're using en_US_POSIX.

More about the en_US_POSIX: https://developer.apple.com/library/ios/qa/qa1480/_index.html

Similar issue: http://stackoverflow.com/questions/20965129/date-formatting-returns-null
